### PR TITLE
Add empty param name support

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -88,6 +88,8 @@ ignore =
   ; Consider possible security implications associated with pickle module
   ; Pickle and modules that wrap it can be unsafe when used to deserialize untrusted data, possible security issue
   S403, S301
+  ; Found too many imported names from a module
+  WPS235
 
 per-file-ignores =
   ; all tests

--- a/README.md
+++ b/README.md
@@ -138,10 +138,13 @@ We have a few steps available for chaining calls:
 This type of step is just an ordinary call of the function.
 If you haven't specified `param_name` argument, then the result
 of the previous step will be passed as the first argument of the function.
-Uf you did specify the `param_name` argument, then the result of the previous
+If you did specify the `param_name` argument, then the result of the previous
 step can be found in key word arguments with the param name you specified.
 
 You can add sequential steps with `.call_next` method of the pipeline.
+
+If you don't want to pass the result of the previous step to the next one,
+you can use `.call_after` method of the pipeline.
 
 ### Mapper step
 

--- a/taskiq_pipelines/__init__.py
+++ b/taskiq_pipelines/__init__.py
@@ -1,5 +1,4 @@
 """Pipelines for taskiq tasks."""
-from taskiq_pipelines.constants import EMPTY_PARAM_NAME
 from taskiq_pipelines.exceptions import AbortPipeline, PipelineError
 from taskiq_pipelines.middleware import PipelineMiddleware
 from taskiq_pipelines.pipeliner import Pipeline
@@ -9,5 +8,4 @@ __all__ = [
     "PipelineError",
     "AbortPipeline",
     "PipelineMiddleware",
-    "EMPTY_PARAM_NAME",
 ]

--- a/taskiq_pipelines/__init__.py
+++ b/taskiq_pipelines/__init__.py
@@ -1,4 +1,5 @@
 """Pipelines for taskiq tasks."""
+from taskiq_pipelines.constants import EMPTY_PARAM_NAME
 from taskiq_pipelines.exceptions import AbortPipeline, PipelineError
 from taskiq_pipelines.middleware import PipelineMiddleware
 from taskiq_pipelines.pipeliner import Pipeline
@@ -8,4 +9,5 @@ __all__ = [
     "PipelineError",
     "AbortPipeline",
     "PipelineMiddleware",
+    "EMPTY_PARAM_NAME",
 ]

--- a/taskiq_pipelines/constants.py
+++ b/taskiq_pipelines/constants.py
@@ -1,2 +1,6 @@
+from typing import Literal
+
 CURRENT_STEP = "_pipe_current_step"
 PIPELINE_DATA = "_pipe_data"
+
+EMPTY_PARAM_NAME: Literal[-1] = -1

--- a/taskiq_pipelines/pipeliner.py
+++ b/taskiq_pipelines/pipeliner.py
@@ -1,5 +1,15 @@
 import json
-from typing import Any, Coroutine, Generic, List, Optional, TypeVar, Union, overload
+from typing import (
+    Any,
+    Coroutine,
+    Generic,
+    List,
+    Literal,
+    Optional,
+    TypeVar,
+    Union,
+    overload,
+)
 
 import pydantic
 from taskiq import AsyncBroker, AsyncTaskiqTask
@@ -58,7 +68,7 @@ class Pipeline(Generic[_FuncParams, _ReturnType]):
             AsyncKicker[Any, Coroutine[Any, Any, _T2]],
             AsyncTaskiqDecoratedTask[Any, Coroutine[Any, Any, _T2]],
         ],
-        param_name: Optional[str] = None,
+        param_name: Union[Optional[str], Literal[-1]] = None,
         **additional_kwargs: Any,
     ) -> "Pipeline[_FuncParams, _T2]":
         ...
@@ -70,7 +80,7 @@ class Pipeline(Generic[_FuncParams, _ReturnType]):
             AsyncKicker[Any, _T2],
             AsyncTaskiqDecoratedTask[Any, _T2],
         ],
-        param_name: Optional[str] = None,
+        param_name: Union[Optional[str], Literal[-1]] = None,
         **additional_kwargs: Any,
     ) -> "Pipeline[_FuncParams, _T2]":
         ...
@@ -81,7 +91,7 @@ class Pipeline(Generic[_FuncParams, _ReturnType]):
             AsyncKicker[Any, Any],
             AsyncTaskiqDecoratedTask[Any, Any],
         ],
-        param_name: Optional[str] = None,
+        param_name: Union[Optional[str], Literal[-1]] = None,
         **additional_kwargs: Any,
     ) -> Any:
         """
@@ -94,7 +104,8 @@ class Pipeline(Generic[_FuncParams, _ReturnType]):
         if param_name is specified.
 
         :param task: task to execute.
-        :param param_name: kwarg param name, defaults to None
+        :param param_name: kwarg param name, defaults to None.
+            If set to -1 (EMPTY_PARAM_NAME), result is not passed.
         :param additional_kwargs: additional kwargs to task.
         :return: updated pipeline.
         """

--- a/taskiq_pipelines/steps/sequential.py
+++ b/taskiq_pipelines/steps/sequential.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Literal, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 import pydantic
 from taskiq import AsyncBroker, AsyncTaskiqDecoratedTask, TaskiqResult
@@ -25,7 +25,17 @@ class SequentialStep(pydantic.BaseModel, AbstractStep, step_name="sequential"):
     additional_kwargs: Dict[str, Any]
 
     @pydantic.validator("param_name")
-    def validate_param_name(cls, value: Union[Optional[str], int]) -> Union[Optional[str], int]:
+    def validate_param_name(
+        self,
+        value: Union[Optional[str], int],
+    ) -> Union[Optional[str], int]:
+        """
+        Validate param_name.
+
+        :param value: value to validate.
+        :raises ValueError: if value is not str, None or -1 (EMPTY_PARAM_NAME).
+        :return: param value.
+        """
         if isinstance(value, int) and value != EMPTY_PARAM_NAME:
             raise ValueError("must be str, None or -1 (EMPTY_PARAM_NAME)")
         return value

--- a/taskiq_pipelines/steps/sequential.py
+++ b/taskiq_pipelines/steps/sequential.py
@@ -1,11 +1,11 @@
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Literal, Optional, Union
 
 import pydantic
 from taskiq import AsyncBroker, AsyncTaskiqDecoratedTask, TaskiqResult
 from taskiq.kicker import AsyncKicker
 
 from taskiq_pipelines.abc import AbstractStep
-from taskiq_pipelines.constants import CURRENT_STEP, PIPELINE_DATA
+from taskiq_pipelines.constants import CURRENT_STEP, EMPTY_PARAM_NAME, PIPELINE_DATA
 
 
 class SequentialStep(pydantic.BaseModel, AbstractStep, step_name="sequential"):
@@ -19,8 +19,16 @@ class SequentialStep(pydantic.BaseModel, AbstractStep, step_name="sequential"):
 
     task_name: str
     labels: Dict[str, str]
-    param_name: Optional[str]
+    # order is important here, otherwise pydantic will always choose str.
+    # we use int instead of Literal[-1] because pydantic thinks that -1 is always str.
+    param_name: Union[Optional[int], str]
     additional_kwargs: Dict[str, Any]
+
+    @pydantic.validator("param_name")
+    def validate_param_name(cls, value: Union[Optional[str], int]) -> Union[Optional[str], int]:
+        if isinstance(value, int) and value != EMPTY_PARAM_NAME:
+            raise ValueError("must be str, None or -1 (EMPTY_PARAM_NAME)")
+        return value
 
     def dumps(self) -> str:
         """
@@ -78,8 +86,10 @@ class SequentialStep(pydantic.BaseModel, AbstractStep, step_name="sequential"):
                 **{PIPELINE_DATA: pipe_data, CURRENT_STEP: step_number},  # type: ignore
             )
         )
-        if self.param_name:
+        if isinstance(self.param_name, str):
             self.additional_kwargs[self.param_name] = result.return_value
+            await kicker.kiq(**self.additional_kwargs)
+        elif self.param_name == EMPTY_PARAM_NAME:
             await kicker.kiq(**self.additional_kwargs)
         else:
             await kicker.kiq(result.return_value, **self.additional_kwargs)
@@ -91,7 +101,7 @@ class SequentialStep(pydantic.BaseModel, AbstractStep, step_name="sequential"):
             AsyncKicker[Any, Any],
             AsyncTaskiqDecoratedTask[Any, Any],
         ],
-        param_name: Optional[str],
+        param_name: Union[Optional[str], int],
         **additional_kwargs: Any,
     ) -> "SequentialStep":
         """


### PR DESCRIPTION
Test code:
```python
import asyncio

from taskiq import InMemoryBroker

from taskiq_pipelines import EMPTY_PARAM_NAME, Pipeline, PipelineMiddleware

broker = InMemoryBroker()
broker.add_middlewares(PipelineMiddleware())


@broker.task
async def add_one(value: int) -> int:
    return value + 1


@broker.task
async def do_nothing() -> None:
    print("I'm doing nothing.")


async def main() -> None:
    # Never forget to call startup in the beginning.
    await broker.startup()

    pipe = (
        Pipeline(broker, add_one).call_next(do_nothing, param_name=EMPTY_PARAM_NAME)
    )
    task = await pipe.kiq(2)

    await asyncio.sleep(2)


if __name__ == "__main__":
    asyncio.run(main())
```