### PR TITLE
Fixed types for coroutine funcs.

### DIFF
--- a/taskiq_pipelines/pipeliner.py
+++ b/taskiq_pipelines/pipeliner.py
@@ -70,9 +70,9 @@ class Pipeline(Generic[_FuncParams, _ReturnType]):
         self: "Pipeline[_FuncParams, _ReturnType]",
         task: Union[
             AsyncKicker[Any, Coroutine[Any, Any, _T2]],
-            AsyncKicker[Any, CoroutineType[Any, Any, _T2]],
+            AsyncKicker[Any, "CoroutineType[Any, Any, _T2]"],
             AsyncTaskiqDecoratedTask[Any, Coroutine[Any, Any, _T2]],
-            AsyncTaskiqDecoratedTask[Any, CoroutineType[Any, Any, _T2]],
+            AsyncTaskiqDecoratedTask[Any, "CoroutineType[Any, Any, _T2]"],
         ],
         param_name: Union[Optional[str], Literal[-1]] = None,
         **additional_kwargs: Any,
@@ -131,9 +131,9 @@ class Pipeline(Generic[_FuncParams, _ReturnType]):
         self: "Pipeline[_FuncParams, _ReturnType]",
         task: Union[
             AsyncKicker[Any, Coroutine[Any, Any, _T2]],
-            AsyncKicker[Any, CoroutineType[Any, Any, _T2]],
+            AsyncKicker[Any, "CoroutineType[Any, Any, _T2]"],
             AsyncTaskiqDecoratedTask[Any, Coroutine[Any, Any, _T2]],
-            AsyncTaskiqDecoratedTask[Any, CoroutineType[Any, Any, _T2]],
+            AsyncTaskiqDecoratedTask[Any, "CoroutineType[Any, Any, _T2]"],
         ],
         **additional_kwargs: Any,
     ) -> "Pipeline[_FuncParams, _T2]": ...
@@ -187,9 +187,9 @@ class Pipeline(Generic[_FuncParams, _ReturnType]):
         self: "Pipeline[_FuncParams, _ReturnType]",
         task: Union[
             AsyncKicker[Any, Coroutine[Any, Any, _T2]],
-            AsyncKicker[Any, CoroutineType[Any, Any, _T2]],
+            AsyncKicker[Any, "CoroutineType[Any, Any, _T2]"],
             AsyncTaskiqDecoratedTask[Any, Coroutine[Any, Any, _T2]],
-            AsyncTaskiqDecoratedTask[Any, CoroutineType[Any, Any, _T2]],
+            AsyncTaskiqDecoratedTask[Any, "CoroutineType[Any, Any, _T2]"],
         ],
         param_name: Optional[str] = None,
         skip_errors: bool = False,
@@ -258,9 +258,9 @@ class Pipeline(Generic[_FuncParams, _ReturnType]):
         self: "Pipeline[_FuncParams, _ReturnType]",
         task: Union[
             AsyncKicker[Any, Coroutine[Any, Any, bool]],
-            AsyncKicker[Any, CoroutineType[Any, Any, bool]],
+            AsyncKicker[Any, "CoroutineType[Any, Any, bool]"],
             AsyncTaskiqDecoratedTask[Any, Coroutine[Any, Any, bool]],
-            AsyncTaskiqDecoratedTask[Any, CoroutineType[Any, Any, bool]],
+            AsyncTaskiqDecoratedTask[Any, "CoroutineType[Any, Any, bool]"],
         ],
         param_name: Optional[str] = None,
         skip_errors: bool = False,

--- a/taskiq_pipelines/pipeliner.py
+++ b/taskiq_pipelines/pipeliner.py
@@ -1,3 +1,4 @@
+from types import CoroutineType
 from typing import (
     Any,
     Coroutine,
@@ -69,7 +70,9 @@ class Pipeline(Generic[_FuncParams, _ReturnType]):
         self: "Pipeline[_FuncParams, _ReturnType]",
         task: Union[
             AsyncKicker[Any, Coroutine[Any, Any, _T2]],
+            AsyncKicker[Any, CoroutineType[Any, Any, _T2]],
             AsyncTaskiqDecoratedTask[Any, Coroutine[Any, Any, _T2]],
+            AsyncTaskiqDecoratedTask[Any, CoroutineType[Any, Any, _T2]],
         ],
         param_name: Union[Optional[str], Literal[-1]] = None,
         **additional_kwargs: Any,
@@ -128,7 +131,9 @@ class Pipeline(Generic[_FuncParams, _ReturnType]):
         self: "Pipeline[_FuncParams, _ReturnType]",
         task: Union[
             AsyncKicker[Any, Coroutine[Any, Any, _T2]],
+            AsyncKicker[Any, CoroutineType[Any, Any, _T2]],
             AsyncTaskiqDecoratedTask[Any, Coroutine[Any, Any, _T2]],
+            AsyncTaskiqDecoratedTask[Any, CoroutineType[Any, Any, _T2]],
         ],
         **additional_kwargs: Any,
     ) -> "Pipeline[_FuncParams, _T2]": ...
@@ -182,7 +187,9 @@ class Pipeline(Generic[_FuncParams, _ReturnType]):
         self: "Pipeline[_FuncParams, _ReturnType]",
         task: Union[
             AsyncKicker[Any, Coroutine[Any, Any, _T2]],
+            AsyncKicker[Any, CoroutineType[Any, Any, _T2]],
             AsyncTaskiqDecoratedTask[Any, Coroutine[Any, Any, _T2]],
+            AsyncTaskiqDecoratedTask[Any, CoroutineType[Any, Any, _T2]],
         ],
         param_name: Optional[str] = None,
         skip_errors: bool = False,
@@ -251,7 +258,9 @@ class Pipeline(Generic[_FuncParams, _ReturnType]):
         self: "Pipeline[_FuncParams, _ReturnType]",
         task: Union[
             AsyncKicker[Any, Coroutine[Any, Any, bool]],
+            AsyncKicker[Any, CoroutineType[Any, Any, bool]],
             AsyncTaskiqDecoratedTask[Any, Coroutine[Any, Any, bool]],
+            AsyncTaskiqDecoratedTask[Any, CoroutineType[Any, Any, bool]],
         ],
         param_name: Optional[str] = None,
         skip_errors: bool = False,


### PR DESCRIPTION
Same fix as in https://github.com/taskiq-python/taskiq/pull/413.